### PR TITLE
Add playback settings sidebar

### DIFF
--- a/style/less/rules.less
+++ b/style/less/rules.less
@@ -42,10 +42,83 @@ a {
     }
 }
 
+// Spacing
+
+section {
+    margin: @space-stack-l;
+}
+
 // Forms
 
 .form-field {
     margin: @space-stack-m;
+    position: relative;
+
+    p {
+        margin: @space-stack-s;
+    }
+
+    // Form toggle switches
+    // The switch - the box around the slider
+    .switch {
+        position: relative;
+        display: inline-block;
+        width: 28px;
+        height: 16px;
+        vertical-align: middle;
+        margin-right: @space-s;
+    }
+
+    // Hides default HTML checkbox
+    .switch input {display:none;}
+
+    // The slider
+    .slider {
+        position: absolute;
+        cursor: pointer;
+        top: 0;
+        left: 0;
+        right: 0;
+        bottom: 0;
+        background-color: #ccc;
+        -webkit-transition: .4s;
+        transition: .4s;
+    }
+
+    .slider:before {
+        position: absolute;
+        content: "";
+        height: 10px;
+        width: 10px;
+        left: 4px;
+        bottom: 3px;
+        background-color: white;
+        -webkit-transition: .4s;
+        transition: .4s;
+    }
+
+    input:checked + .slider {
+        background-color: @teal-500;
+    }
+
+    input:focus + .slider {
+        box-shadow: 0 0 1px @teal-500;
+    }
+
+    input:checked + .slider:before {
+        -webkit-transform: translateX(14px);
+        -ms-transform: translateX(14px);
+        transform: translateX(14px);
+    }
+
+    // Rounded sliders
+    .slider.round {
+        border-radius: 34px;
+    }
+
+    .slider.round:before {
+        border-radius: 50%;
+    }
 }
 
 label {
@@ -68,6 +141,29 @@ input[type=text], textarea {
     padding: @space-squish-s;
     width: 100%;
     margin-top: @space-xs;
+}
+
+input[type=radio] {
+    margin-right: @space-s;
+}
+
+.form-help-text {
+    font-family: @base-font-family;
+    font-size: 0.7em;
+    font-style: italic;
+    color: @gray-700;
+    margin: @space-stack-s;
+    &.radio {
+        margin: 0 0 @space-s 22px;
+    }
+}
+
+select {
+    box-sizing: border-box;
+    cursor: pointer;
+    .border-radius(2px);
+    border: 1px solid @gray-300;
+    .clearfix();
 }
 
 // Header
@@ -150,31 +246,34 @@ header {
 .sidebar-nav {
     background-color: @gray-300;
     height: 100%;
+    a {
+        color: @gray-800;
+    }
     i {
         padding: 8px 16px 8px 21px;
         border-width: 1px 1px 0 5px;
         border-color: @gray-400;
         border-style: solid;
+        border-left: 5px solid @gray-300;
+        width: 65px;
         text-align: center;
         cursor: pointer;
         box-sizing: border-box;
         &.active {
             color: @teal-500;
             background-color: @gray-50;
-            border-width: 0 0 0 5px;
-            border-color: @teal-500;
+            border-width: 1px 1px 0 5px;
+            border-color: @gray-50;
             border-style: solid;
-            box-sizing: border-box;
-            padding: 8px 17px 9px 21px;
+            border-left: 5px solid @teal-500;
         }
         &:hover {
             color: @teal-300;
             background-color: @gray-25;
-            border-width: 0 0 0 5px;
-            border-color: @teal-300;
+            border-width: 1px 1px 0 5px;
+            border-color: @gray-25;
             border-style: solid;
-            box-sizing: border-box;
-            padding: 8px 17px 9px 21px;
+            border-left: 5px solid @teal-300;
         }
     }
 }

--- a/style/less/variables.less
+++ b/style/less/variables.less
@@ -63,7 +63,7 @@
 @gray-1000: #000000;
 
 @teal-100: #bcdadb;
-@teal-300: #00b8c0;
+@teal-300: #00c8d4;
 @teal-500: #00abaf;
 
 @blue-300: #0e83e8;

--- a/templates/chapter_info.html
+++ b/templates/chapter_info.html
@@ -34,12 +34,12 @@
             </div>
             <div class="sidebar-main">
                 <nav class="sidebar-nav">
-                    <i class="fa fa-info-circle active"></i>
-                    <i class="fa fa-play-circle-o"></i>
-                    <i class="fa fa-list-alt"></i>
-                    <i class="fa fa-clone"></i>
-                    <i class="fa fa-map-pin"></i>
-                    <i class="fa fa-object-group"></i>
+                    <a href="#"><i class="fa fa-info-circle active"></i></a>
+                    <a href="playback_settings.html"><i class="fa fa-play-circle-o"></i></a>
+                    <a href="#"><i class="fa fa-list-alt"></i></a>
+                    <a href="#"><i class="fa fa-clone"></i></a>
+                    <a href="#"><i class="fa fa-map-pin"></i></a>
+                    <a href="#"><i class="fa fa-object-group"></i></a>
                 </nav>
                 <div class="sidebar-content">
                     <h2 class="section-title">Chapter Info</h2>

--- a/templates/playback_settings.html
+++ b/templates/playback_settings.html
@@ -1,0 +1,97 @@
+<html>
+    <head>
+        <link href="https://fonts.googleapis.com/css?family=Lato:400,400i,700,900" rel="stylesheet">
+        <link href="../style/css/test.css" rel="stylesheet">
+        <script src="https://use.fontawesome.com/9690d4cb85.js"></script>
+        <script src="../modernizr.js"></script>
+    </head>
+    <body>
+        <header>
+            <div class="story-info">
+                <h1>Story Title</h1>
+                <a href="#">Edit story info</a>
+            </div>
+            <div class="preview">
+                <i class="fa fa-toggle-off"></i>
+                <p>Preview mode</p>
+            </div>
+            <div class="autosave">
+                <p>Last edit was 6 days ago<p>
+                <button>Save</button>
+                <button>Publish</button>
+            </div>
+        </header>
+        <div class="sidebar">
+            <div class="sidebar-header">
+                <div class="chapter-header">
+                    <a href="table_of_contents.html" class="toc-link">Table of Contents</a>
+                    <div class="chapter-nav">
+                        <a href="#" class="arrow"><i class="fa fa-caret-left"></i></a>
+                        <h1 class="sidebar-title">01 <strong>Chapter Name</strong></h1>
+                        <a href="#" class="arrow"><i class="fa fa-caret-right"></i></a>
+                    </div>
+                </div>
+            </div>
+            <div class="sidebar-main">
+                <nav class="sidebar-nav">
+                    <a href="chapter_info.html"><i class="fa fa-info-circle"></i></a>
+                    <a href="#"><i class="fa fa-play-circle-o active"></i></a>
+                    <a href="#"><i class="fa fa-list-alt"></i></a>
+                    <a href="#"><i class="fa fa-clone"></i></a>
+                    <a href="#"><i class="fa fa-map-pin"></i></a>
+                    <a href="#"><i class="fa fa-object-group"></i></a>
+                </nav>
+                <div class="sidebar-content">
+                    <section>
+                        <h2 class="section-title">Chapter Playback Settings</h2>
+                        <form>
+                            <div class="form-field">
+                                <label for="chapter_title">Data Playback</label>
+                                <strong><abbr title="required">*</abbr></strong>
+                                <br />
+                                <input type="radio" name="data_playback" value="instant" id="instant"><label for="instant">Instant playback</label><br />
+                                <div class="form-help-text radio">Shows features only during their start date.</div>
+                                <input type="radio" name="data_playback" value="cumulative" id="cumulative"><label for="cumulative">Cumulative playback</label><br />
+                                <div class="form-help-text radio">Shows features from their start date until the end of the chapter.</div>
+                                <input type="radio" name="data_playback" value="range" id="range"><label for="range">Range playback</label><br />
+                                <div class="form-help-text radio">Shows features from their start date to their end date.</div>
+                            </div>
+                        </form>
+                    </section>
+                    <h2 class="section-title">Map Control Settings</h2>
+                      <form>
+                        <div class="form-field">
+                            <label for="basemap">Basemap</label>
+                            <strong><abbr title="required">*</abbr></strong><br />
+                            <select name="basemap">
+                                <option value="osm">OpenStreetMap</option>
+                                <option value="human_osm">Humanitarian OpenStreetMap</option>
+                                <option value="natural_earth">Natural Earth</option>
+                                <option value="natural_earth2">Natural Earth 2</option>
+                                <option value="geography_class">Geography Class</option>
+                                <option value="MapBoxControlRoom">MapBox Control Room</option>
+                                <option value="world_dark">World Dark</option>
+                                <option value="world_light">World Light</option>
+                                <option value="esri_ngs">Esri NGS</option>
+                            </select>
+                        </div>
+                        <div class="form-field">
+                            <p>Choose what map controls viewers will see for this chapter when they play your MapStory or embed your map.</p>
+                            <label class="switch">
+                                <input type="checkbox" for="timeline">
+                                <div class="slider round"></div>
+                            </label>
+                            <label for="timeline">Timeline open by default</label>
+                            <br />
+                            <label class="switch">
+                                <input type="checkbox" for="sidebar">
+                                <div class="slider round"></div>
+                            </label>
+                            <label for="sidebar">Summary sidebar open by default</label>
+                        </div>
+                    </form>
+                </div>
+            </div>
+        </div>
+    </body>
+</html>


### PR DESCRIPTION
This PR closes the following MapStory issues:
- https://github.com/MapStory/mapstory/issues/400
- https://github.com/MapStory/mapstory/issues/406

It adds links to the sidebar navigation and tweaks to its color appearance. Also new: the playback settings tab, and styles for a few more form elements like toggle switches. Sidebar nav links to pages that exist currently (see gif below).

<img width="435" alt="screen shot 2017-02-17 at 10 08 50 am" src="https://cloud.githubusercontent.com/assets/1529366/23072902/1e6ec554-f4f9-11e6-88e2-969cf3ed5542.png">

![feb-17-2017 10-01-01](https://cloud.githubusercontent.com/assets/1529366/23072735/72d1f2fc-f4f8-11e6-929a-eccfec76ee7c.gif)
